### PR TITLE
Add Jest tests and app adjustments

### DIFF
--- a/server/api/jest.config.js
+++ b/server/api/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  setupFiles: ['<rootDir>/tests/setupEnv.ts'],
+};

--- a/server/api/src/index.ts
+++ b/server/api/src/index.ts
@@ -16,7 +16,7 @@ import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import promMiddleware from 'express-prometheus-middleware';
 
-class App {
+export class App {
   public app: express.Application;
   private port: number;
   private server: Server | null = null;
@@ -261,11 +261,13 @@ process.on('SIGINT', () => {
   process.exit(0);
 });
 
-// Start application
+// Start application unless running in a test environment
 const app = new App();
-app.start().catch((error) => {
-  logger.error('Failed to start application:', error);
-  process.exit(1);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.start().catch((error) => {
+    logger.error('Failed to start application:', error);
+    process.exit(1);
+  });
+}
 
 export default app;

--- a/server/api/tests/app.test.ts
+++ b/server/api/tests/app.test.ts
@@ -1,0 +1,20 @@
+import request from 'supertest';
+import { App } from '../src/index';
+
+const appInstance = new App();
+
+describe('API basic endpoints', () => {
+  const app = appInstance.getApp();
+
+  test('health endpoint', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  test('test endpoint', async () => {
+    const res = await request(app).get('/api/v1/test');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/server/api/tests/setupEnv.ts
+++ b/server/api/tests/setupEnv.ts
@@ -1,0 +1,4 @@
+process.env.FIREBASE_PROJECT_ID = 'test-project';
+process.env.GOOGLE_APPLICATION_CREDENTIALS = 'service-account-key.json';
+process.env.REDIS_URL = 'memory://localhost';
+process.env.NODE_ENV = 'test';


### PR DESCRIPTION
## Summary
- export `App` class and allow skipping startup when NODE_ENV=test
- add Jest configuration and basic health/test endpoint coverage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431aa9768c83258257c6c4a092b10b